### PR TITLE
fix passing isrefresh from javascript to php

### DIFF
--- a/js/simple-likes-public.js
+++ b/js/simple-likes-public.js
@@ -23,6 +23,7 @@
 					post_id : post_id,
 					nonce : security,
 					is_comment : iscomment,
+					is_refresh : isrefresh,
 				},
 				beforeSend:function(){
 					loader.html('&nbsp;<div class="loader">Loading...</div>');

--- a/post-like.php
+++ b/post-like.php
@@ -52,7 +52,7 @@ function process_simple_like() {
 	$is_comment = ( isset( $_REQUEST['is_comment'] ) && $_REQUEST['is_comment'] == 1 ) ? 1 : 0;
 	// Base variables
 	$post_id = ( isset( $_REQUEST['post_id'] ) && is_numeric( $_REQUEST['post_id'] ) ) ? $_REQUEST['post_id'] : '';
-	$is_refresh = ( isset( $_REQUEST['is_refresh'] ) && $_REQUEST['is_refresh'] == true ) ? true : false;
+	$is_refresh = ( isset( $_REQUEST['is_refresh'] ) && $_REQUEST['is_refresh'] == "true" ) ? true : false;
 	$result = array();
 	$post_users = NULL;
 	$like_count = 0;


### PR DESCRIPTION
Hi,
I think the refresh functionality is useful. 

While debugging I noticed that the javascript "isrefresh" is not passed to php in the ajax POST. 
As result `$is_refresh = ( isset( $_REQUEST['is_refresh'] ) [..]` is always false and triggers a 'Like' when the page loads.

Greetings from Vienna